### PR TITLE
Support dynamic session timeout

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
@@ -36,6 +36,7 @@ import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.SessionState;
 import com.microsoft.applicationinsights.telemetry.SessionStateTelemetry;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ServletUtils;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.cookies.HttpCookieFactory;
 import com.microsoft.applicationinsights.web.internal.cookies.SessionCookie;
@@ -158,10 +159,20 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule, Te
             return;
         }
 
+        int sessionTimeout = getSessionTimeout(req);
         SessionContext sessionContext = getTelemetrySessionContext(context);
-        Cookie cookie = HttpCookieFactory.generateSessionHttpCookie(context, sessionContext);
+        Cookie cookie = HttpCookieFactory.generateSessionHttpCookie(context, sessionContext, sessionTimeout);
 
         res.addCookie(cookie);
+    }
+
+    private int getSessionTimeout(ServletRequest servletRequest) {
+        Integer sessionTimeout = ServletUtils.getRequestSessionTimeout(servletRequest);
+        if (sessionTimeout == null) {
+            sessionTimeout = SessionCookie.SESSION_DEFAULT_EXPIRATION_TIMEOUT_IN_MINUTES;
+        }
+
+        return sessionTimeout;
     }
 
     private SessionContext getTelemetrySessionContext(RequestTelemetryContext aiContext) {

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ServletUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ServletUtils.java
@@ -1,0 +1,109 @@
+/*
+ * AppInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.web.internal;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathFactory;
+import java.io.InputStream;
+
+/**
+ * Created by yonisha on 3/11/2015.
+ */
+public class ServletUtils {
+
+    private static Integer applicationDescriptorDefaultInMinutes;
+
+    // region Public
+
+    /**
+     * Gets the request session timeout.
+     * First, checks for dynamic session timeout by checking if a servlet session has been created for the request.
+     * If not exists, checks for static session timeout configured in the application descriptor (web.xml).
+     *
+     * @param servletRequest The servlet request.
+     * @return The session timeout in seconds or null if no session timeout has been configured.
+     */
+    public static Integer getRequestSessionTimeout(ServletRequest servletRequest) {
+        Integer sessionTimeout = null;
+
+        try {
+            sessionTimeout = tryGetSessionTimeoutFromCurrentServletSession(servletRequest);
+
+            if (sessionTimeout == null) {
+                sessionTimeout = tryGetSessionTimeoutFromApplicationDescriptor(servletRequest);
+            }
+        } catch (Exception e) {
+        }
+
+        return sessionTimeout;
+    }
+
+    // endregion Public
+
+    // region Private
+
+    /**
+     * Session timeout extracted from the request can varied from one request to another, in the case where a developer
+     * dynamically sets the session timeout during request processing.
+     * The session can be null if no user session initialized or a session was initialized in a subsequent filter.
+     */
+    private static Integer tryGetSessionTimeoutFromCurrentServletSession(ServletRequest servletRequest) {
+        HttpSession session = ((HttpServletRequest) servletRequest).getSession(false);
+
+        Integer timeout = null;
+        if (session != null) {
+            timeout = session.getMaxInactiveInterval();
+        }
+
+        return timeout;
+    }
+
+    /**
+     * Session timeout extracted from the application descriptor (web.xml) is static and not changed during application
+     * lifecycle. Therefore, to reduce I/O and improve performance, we store the session timeout in a static member to
+     * be used in subsequent calls.
+     * The application descriptor is searched under WEB-INF folder which is commonly used.
+     */
+    private static Integer tryGetSessionTimeoutFromApplicationDescriptor(ServletRequest servletRequest) throws Exception {
+        final String sessionTimeoutXmlPath = "\"web-app/session-config/session-timeout\"";
+        final String applicationDescriptorFilePath = "/WEB-INF/web.xml";
+
+        if (applicationDescriptorDefaultInMinutes != null) {
+            return applicationDescriptorDefaultInMinutes;
+        }
+
+        InputStream resourceAsStream = servletRequest.getServletContext().getResourceAsStream(applicationDescriptorFilePath);
+        applicationDescriptorDefaultInMinutes =
+                Integer.parseInt(XPathFactory.newInstance().newXPath().
+                        compile(sessionTimeoutXmlPath).
+                        evaluate(DocumentBuilderFactory.newInstance().newDocumentBuilder().
+                                parse(resourceAsStream)));
+
+        Integer applicationDescriptorDefaultInSeconds = applicationDescriptorDefaultInMinutes * 60;
+        return applicationDescriptorDefaultInSeconds;
+    }
+
+    // endregion Private
+}

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/HttpCookieFactory.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/HttpCookieFactory.java
@@ -42,14 +42,16 @@ public class HttpCookieFactory {
      * Generates session http cookie.
      * @param context The context.
      * @param sessionContext The request session context.
+     * @param sessionTimeoutInMinutes The session timeout in minutes.
      * @return Session http cookie.
      */
-    public static Cookie generateSessionHttpCookie(RequestTelemetryContext context, SessionContext sessionContext) {
+    public static Cookie generateSessionHttpCookie(
+            RequestTelemetryContext context, SessionContext sessionContext, int sessionTimeoutInMinutes) {
         Date renewalDate = DateTimeUtils.getDateTimeNow();
         Date expirationDate = DateTimeUtils.addToDate(
                 renewalDate,
                 Calendar.MINUTE,
-                SessionCookie.SESSION_DEFAULT_EXPIRATION_TIMEOUT_IN_MINUTES);
+                sessionTimeoutInMinutes);
         long timeDiffInSeconds = DateTimeUtils.getDateDiff(expirationDate, DateTimeUtils.getDateTimeNow(), TimeUnit.SECONDS);
 
         String formattedCookie = SessionCookie.formatCookie(new String[] {

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ServletUtilsTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ServletUtilsTests.java
@@ -1,0 +1,75 @@
+/*
+ * AppInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.web.internal;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by yonisha on 3/11/2015.
+ */
+public class ServletUtilsTests {
+
+    private HttpServletRequest servletRequest;
+
+    @Before
+    public void testInitialize() {
+        servletRequest = mock(HttpServletRequest.class);
+    }
+
+    @Test
+    public void testCheckServletSessionWithoutCreatingNewSession() {
+        ServletUtils.getRequestSessionTimeout(servletRequest);
+
+        verify(servletRequest).getSession(false);
+    }
+
+    @Test
+    public void testIfHttpSessionExistsMaxInactiveIntervalReturned() {
+        final int maxInactiveInterval = 10;
+
+        HttpSession httpSession = mock(HttpSession.class);
+        when(httpSession.getMaxInactiveInterval()).thenReturn(maxInactiveInterval);
+        when(servletRequest.getSession(false)).thenReturn(httpSession);
+
+        int requestSessionTimeout = ServletUtils.getRequestSessionTimeout(servletRequest);
+
+        Assert.assertEquals(maxInactiveInterval, requestSessionTimeout);
+    }
+
+    @Test
+    public void testWhenHttpSessionNotExistsApplicationDescriptorIsChecked() {
+        when(servletRequest.getSession(false)).thenReturn(null);
+
+        ServletUtils.getRequestSessionTimeout(servletRequest);
+
+        verify(servletRequest).getServletContext();
+    }
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/cookies/SessionCookieTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/cookies/SessionCookieTests.java
@@ -137,9 +137,18 @@ public class SessionCookieTests {
 
     @Test
     public void testSessionHttpCookiePathSetForAllPages() {
-        Cookie cookie = HttpCookieFactory.generateSessionHttpCookie(requestTelemetryContextMock, sessionContext);
+        Cookie cookie = HttpCookieFactory.generateSessionHttpCookie(requestTelemetryContextMock, sessionContext, 10);
 
         Assert.assertEquals("Path should catch all urls", HttpCookieFactory.COOKIE_PATH_ALL_URL, cookie.getPath());
+    }
+
+    @Test
+    public void testSessionHttpCookieSetMaxAge() {
+        final int sessionTimeoutInMinutes = 10;
+
+        Cookie cookie = HttpCookieFactory.generateSessionHttpCookie(requestTelemetryContextMock, sessionContext, sessionTimeoutInMinutes);
+
+        Assert.assertEquals(sessionTimeoutInMinutes * 60, cookie.getMaxAge());
     }
 
     // endregion Tests


### PR DESCRIPTION
The session timeout can now be configured in two ways:
1. If a servlet level session (HttpSession) was already created, the session timeout will be taken from the session.
2. If no servlet level session exists, the timeout will be taken from from the application descriptor (web.xml).
3. Otherwise, default timeout.