### PR TITLE
Loading default PCs as fallback for JBoss web servers

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -178,6 +178,14 @@ public enum TelemetryConfigurationFactory {
 
         final List<String> performanceModuleNames =
                 new AnnotationPackageScanner().scanForClassAnnotations(new Class[]{PerformanceModule.class}, performanceCountersSection);
+
+        if (performanceModuleNames.size() == 0) {
+
+            // Only a workaround for JBoss web servers.
+            // Will be removed once the issue will be investigated and fixed.
+            performanceModuleNames.addAll(getDefaultPerformanceModulesNames());
+        }
+
         for (String performanceModuleName : performanceModuleNames) {
             TelemetryModule module = createInstance(performanceModuleName, TelemetryModule.class);
             if (module != null) {
@@ -192,6 +200,19 @@ public enum TelemetryConfigurationFactory {
         }
 
         loadCustomJmxPCs(performanceConfigurationData.getJmxXmlElements());
+
+        return modules;
+    }
+
+    /**
+     * This method is only a workaround until the failure to load PCs in JBoss web servers will be solved.
+     */
+    private List<String> getDefaultPerformanceModulesNames() {
+        InternalLogger.INSTANCE.trace("Default performance counters will be automatically loaded.");
+
+        ArrayList<String> modules = new ArrayList<String>();
+        modules.add("com.microsoft.applicationinsights.internal.perfcounter.ProcessPerformanceCountersModule");
+        modules.add("com.microsoft.applicationinsights.web.internal.perfcounter.WebPerformanceCounterModule");
 
         return modules;
     }


### PR DESCRIPTION
In case of a failure to scan for PC modules in a JBoss web server, I simply load the modules by providing hard-coded module names.

This is only a TEMPORARY solution until we'll investigate and understand why the annotation scanner fail to run. I don't think we should invest more on it right now since the ROI is low (we get the same result with hard-coded module names but with the price of ugly workaround).

Guy, note that I saw only 'private byte' and 'process CPU' PCs have been registered. Does it make sense?